### PR TITLE
Revert "MTL-1748 Handle NVME partition naming"

### DIFF
--- a/93metalluksetcd/metal-luksetcd-lib.sh
+++ b/93metalluksetcd/metal-luksetcd-lib.sh
@@ -82,11 +82,6 @@ make_etcd() {
     # Wipe our disk.
     parted --wipesignatures --ignore-busy -s "/dev/${target}" mktable gpt
 
-    # NVME partitions have a "p" to delimit the partition number.
-    if [[ "$target" =~ "nvme" ]]; then
-        target="${target}p" 
-    fi
-
     # LUKS2 header requires multiple writes, silence warnings of race-condition when /run/cryptsetup does not exist
     # citation: https://lists.debian.org/debian-boot/2019/02/msg00100.html
     info Attempting luksFormat of "/dev/${target}" ...


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Relates to: MTL-1748

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
The luks partition was failing to create in GCP on NVME. The addition from MTL-1748 ends up targeting a partition, but the luks commands need to target the entire disk. Furthermore the partition that's targeted doesn't exist.

This code block had been tested on hermod, but not thoroughly enough. Removing the block was tested on GCP and proved to work.

This reverts commit 187c0e6a66656852f750d14d9b0fca6a60a5a302.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
Since there are no metal NVME servers to test this on, it is possible that a change will be needed in the future.

However the LUKS device never creates a partition, as seen on a non-NVME server there is no `1` partition on the LUKS device:

```bash
# There is no sdc1
sdc                          8:32   0 447.1G  0 disk
└─ETCDLVM                  254:1    0 447.1G  0 crypt
  └─etcdvg0-ETCDK8S        254:2    0    32G  0 lvm   /run/lib-etcd
```

Going off of this, reverting this codeblock should support both metal and GCP.