### PR TITLE
MTL-1839 Ensure Early Exit on KDUMP

### DIFF
--- a/93metalluksetcd/metal-luksetcd-genrules.sh
+++ b/93metalluksetcd/metal-luksetcd-genrules.sh
@@ -25,6 +25,15 @@
 # metal-luksetcd-genrules.sh
 [ "${metal_debug:-0}" = 0 ] || set -x
 
+command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+case "$(getarg root)" in 
+    kdump)
+        # do not do anything for kdump
+        exit 0
+        ;;
+esac
+
 command -v getargbool > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
 # Only run when luks is enabled and a deployment server is present.

--- a/93metalluksetcd/metal-luksetcd-unlock.sh
+++ b/93metalluksetcd/metal-luksetcd-unlock.sh
@@ -23,10 +23,22 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 # metal-luksetcd-unlock.sh
+[ "${metal_debug:-0}" = 0 ] || set -x
+
+command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+case "$(getarg root)" in 
+    kdump)
+        # do not do anything for kdump
+        exit 0
+        ;;
+esac
+
 if [ $metal_noluks = 0 ]; then 
     echo >&2 'skipping unlocking of LUKS devices (rd.luks=0 was set on the cmdline)'
     exit 0
 fi
+
 etcdk8s_scheme=${metal_etcdk8s%=*}
 etcdk8s_authority=${metal_etcdk8s#*=}
 

--- a/93metalluksetcd/metal-update-keystore.sh
+++ b/93metalluksetcd/metal-update-keystore.sh
@@ -33,7 +33,6 @@
 #
 #   2. rd.luks=1 (or rd.luks) must be set to enable this function.
 #
-set -u
 [ "${metal_debug:-0}" = 0 ] || set -x
 
 if [ $metal_noluks = 0 ]; then 
@@ -47,7 +46,18 @@ perms() {
     find $metal_keystore -type d -exec chmod 700 {} \+
     find $metal_keystore -type f -exec chmod 400 {} \+
 }
-trap perms EXIT
+
+command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
+
+case "$(getarg root)" in 
+    kdump)
+        # do not do anything for kdump
+        exit 0
+        ;;
+    *)
+        trap perms EXIT
+        ;;
+esac
 
 # Do not create parent directories with '-p'.etcd_master_key, if the parent
 # does not exist then our persistent storage hasn't mounted or is invalid and


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1839
- Relates to: CASMTRIAGE-3591

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Remove the need to remember to omit this module during kdump initrd generation.

##### k8s-master example

```bash
ncn-m003:~ # echo c>/proc/sysrq-trigger
[  410.378980] sysrq: Trigger a crash
[  410.382392] Kernel panic - not syncing: sysrq triggered crash
[  410.388139] CPU: 65 PID: 17814 Comm: bash Kdump: loaded Tainted: G               X    5.3.18-150300.59.76-default #1 SLE15-SP3
[  410.399521] Hardware name: Intel Corporation S2600WFT/S2600WFT, BIOS SE5C620.86B.02.01.0012.C0001.070720200218 07/07/2020
[  410.410465] Call Trace:
[  410.412928]  dump_stack+0x66/0x8b
[  410.416252]  panic+0xfe/0x2d7
[  410.419225]  ? printk+0x52/0x6e
[  410.422378]  sysrq_handle_crash+0x11/0x20
[  410.426387]  __handle_sysrq+0x89/0x140
[  410.430139]  write_sysrq_trigger+0x2b/0x30
[  410.434243]  proc_reg_write+0x39/0x60
[  410.437916]  vfs_write+0xad/0x1b0
[  410.441231]  ksys_write+0xa1/0xe0
[  410.444553]  do_syscall_64+0x5b/0x1e0
[  410.448219]  entry_SYSCALL_64_after_hwframe+0x44/0xa9
[  410.453269] RIP: 0033:0x7f1cdfac0b13
[  410.456846] Code: 0f 1f 80 00 00 00 00 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 90 64 8b 04 25 18 00 00 00 85 c0 75 14 b8 01 00 00 00 0f 05 <48> 3d 00 f0 ff ff 77 55 f3 c3 0f 1f 00 41 54 55 49 89 d4 53 48 89
[  410.475592] RSP: 002b:00007ffdb9af5738 EFLAGS: 00000246 ORIG_RAX: 0000000000000001
[  410.483155] RAX: ffffffffffffffda RBX: 0000000000000002 RCX: 00007f1cdfac0b13
[  410.490287] RDX: 0000000000000002 RSI: 00005569ca40d920 RDI: 0000000000000001
[  410.497418] RBP: 00005569ca40d920 R08: 000000000000000a R09: 0000000000000000
[  410.504550] R10: 00007f1cdf9c1468 R11: 0000000000000246 R12: 00007f1cdfda4500
[  410.511683] R13: 0000000000000002 R14: 00007f1cdfda9c00 R15: 0000000000000002
[    0.115277] [Firmware Bug]: the BIOS has corrupted hw-PMU resources (MSR 38d is b0)
�[    2.141224] mce: Unable to init MCE device (rc: -5)
Unable to ioctl(KDSETLED) -- are you not on the console? (Inappropriate ioctl for device)
mount: /kdump/rootfsbase: cannot remount /kdump/live/LiveOS/filesystem.squashfs read-write, is write-protected.
Nothing to delete in /kdump/overlay/LiveOS/overlay-SQFSRAID-bbf8bf96-5b26-4a8d-9396-54ca1ef46d0f/var/crash.
Extracting dmesg
-------------------------------------------------------------------------------

The dmesg log is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-bbf8bf96-5b26-4a8d-9396-54ca1ef46d0f/var/crash/2022-07-08-21:13/dmesg.txt.

makedumpfile Completed.
-------------------------------------------------------------------------------
Saving dump using makedumpfile
-------------------------------------------------------------------------------
Copying data                                      : [100.0 %] |           eta: 0s

The dumpfile is saved to /kdump/overlay/LiveOS/overlay-SQFSRAID-bbf8bf96-5b26-4a8d-9396-54ca1ef46d0f/var/crash/2022-07-08-21:13/vmcore.

makedumpfile Completed.
-------------------------------------------------------------------------------
Generating README              Finished.
Copying System.map             Finished.
Copying kernel                 Finished.
umount: /kdump/overlay: not mounted.
umount: /kdump/rootfsbase: not mounted.
umount: /kdump/live: not mounted.
umount: /sys/fs/cgroup/unified: target is busy.
umount: /sys/fs/cgroup: target is busy.
umount: /run: target is busy.
umount: /dev: target is busy.
umount: /: not mounted.
Rebooting.
[   64.805126] reboot: Restarting system
```

Mounts were fine in diskboots and netboots:
```bash
ncn-m003:~ # lsblk
NAME                       MAJ:MIN RM   SIZE RO TYPE  MOUNTPOINT
loop0                        7:0    0   5.3G  1 loop  /run/rootfsbase
loop1                        7:1    0   3.2G  0 loop
└─live-overlay-pool        254:0    0    32G  0 dm
loop2                        7:2    0    32G  0 loop
└─live-overlay-pool        254:0    0    32G  0 dm
sda                          8:0    0 447.1G  0 disk
└─ETCDLVM                  254:2    0 447.1G  0 crypt
  └─etcdvg0-ETCDK8S        254:3    0    32G  0 lvm   /run/lib-etcd
sdb                          8:16   0 447.1G  0 disk
├─sdb1                       8:17   0   476M  0 part
│ └─md125                    9:125  0 475.9M  0 raid1 /metal/recovery
├─sdb2                       8:18   0  22.8G  0 part
│ └─md127                    9:127  0  22.8G  0 raid1 /run/initramfs/live
├─sdb3                       8:19   0 139.7G  0 part
│ └─md126                    9:126  0 139.6G  0 raid1 /run/initramfs/overlayfs
└─sdb4                       8:20   0 139.7G  0 part
  └─md124                    9:124  0 279.1G  0 raid0
    └─metalvg0-CRAYS3CACHE 254:1    0   200G  0 lvm   /var/lib/s3fs_cache
sdc                          8:32   0 447.1G  0 disk
├─sdc1                       8:33   0   476M  0 part
│ └─md125                    9:125  0 475.9M  0 raid1 /metal/recovery
├─sdc2                       8:34   0  22.8G  0 part
│ └─md127                    9:127  0  22.8G  0 raid1 /run/initramfs/live
├─sdc3                       8:35   0 139.7G  0 part
│ └─md126                    9:126  0 139.6G  0 raid1 /run/initramfs/overlayfs
└─sdc4                       8:36   0 139.7G  0 part
  └─md124                    9:124  0 279.1G  0 raid0
    └─metalvg0-CRAYS3CACHE 254:1    0   200G  0 lvm   /var/lib/s3fs_cache
```

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
