### PR TITLE
MTL-1863 Add `%posttrans`

### DIFF
--- a/dracut-metal-luksetcd.spec
+++ b/dracut-metal-luksetcd.spec
@@ -88,4 +88,12 @@ cp -pvrR ./%{module_name}/* %{buildroot}%{dracut_modules}/%{module_name} | awk '
 
 %preun
 
+%posttrans
+mkinitrd -B
+
+if rpm -q kdump 2>&1 >/dev/null ; then
+    mkdumprd -f
+fi
+
+
 %changelog


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-1863

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Invoke both `mkinitrd` and `mkdumprd`, no need for updating the bootloader.

This will ensure that installing or upgrading this package will entail including this module in the existing initrd.

Currently we do this by hand by invoking the `create-kis-artifacts.sh` script in our NCN builds, but in general this RPM should do this automatically.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
