### PR TITLE
MTL-2441 Drop `--pbkdf` argument on `luksOpen`

### DIFF
--- a/93metalluksetcd/metal-luksetcd-lib.sh
+++ b/93metalluksetcd/metal-luksetcd-lib.sh
@@ -49,7 +49,7 @@ scan_etcd() {
 ##############################################################################
 # function: make_etcd
 #
-# Returns 0 if a disk was partitioned and encrypted, otherwise this calls 
+# Returns 0 if a disk was partitioned and encrypted, otherwise this calls
 # metal_die with a contextual error message.
 #
 # Requires 1 argument for which disk:
@@ -60,7 +60,7 @@ scan_etcd() {
 # NOTE: The disk name must be given without any partitions or `/dev` prefixed
 #       paths.
 make_etcd() {
-    
+
     local target="${1:-}" && shift
     if [ -z "$target" ]; then
         info 'No etcd disk.'
@@ -100,7 +100,6 @@ make_etcd() {
             --batch-mode \
             --allow-discards \
             --type=luks2 \
-            --pbkdf=argon2id \
             luksOpen "/dev/${target}" "${ETCDLVM:-ETCDLVM}" || metal_luksetcd_die 'FATAL could not open LUKS device for ETCD'
 
     # Start with etcdvg0 to allow for etcdvgN for new etcd volume groups.

--- a/93metalluksetcd/metal-luksetcd-unlock.sh
+++ b/93metalluksetcd/metal-luksetcd-unlock.sh
@@ -31,14 +31,14 @@ exec > "${METAL_LOG_DIR}/metal-luksetcd-unlock.log" 2>&1
 
 command -v getarg > /dev/null 2>&1 || . /lib/dracut-lib.sh
 
-case "$(getarg root)" in 
+case "$(getarg root)" in
     kdump)
         # do not do anything for kdump
         exit 0
         ;;
 esac
 
-if [ $metal_noluks = 0 ]; then 
+if [ $metal_noluks = 0 ]; then
     echo >&2 'skipping unlocking of LUKS devices (rd.luks=0 was set on the cmdline)'
     exit 0
 fi
@@ -60,7 +60,6 @@ if ! blkid -s UUID -o value "/dev/disk/by-${etcdk8s_scheme,,}/${etcdk8s_authorit
             --batch-mode \
             --allow-discards \
             --type=luks2 \
-            --pbkdf=argon2id \
             luksOpen "${etcd_disk}" "${ETCDLVM:-ETCDLVM}"
     /sbin/lvm_scan
 fi


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2441
- Relates t o:

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
`--pbkdf` is no longer a valid argument to `luksOpen`; using it causes cryptsetup>2.4.3 to print usage and exit.

Our mount opens just fine without this argument
```bash
sh-4.4# cryptsetup --key-file /tmp/metalpki/etcd.key \
>             --verbose \
>             --batch-mode \
>             --allow-discards \
>             --type=luks2 \
> luksOpen "/dev/sdd" ETCDLVM
No usable token is available.
Key slot 0 unlocked.
Command successful.
```

The default `PBKDF2` for luks2 is `argon2id`. The argument was explicitly called out for strictness; it can be removed without repercussions from our `lukeOpen` calls.
### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
